### PR TITLE
Address items from the review

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -8,18 +8,19 @@ After the install is complete, Twistlock Defender will be running in your enviro
 
 ##<a id='install'></a> Import the Twistlock Tile
 
-1. Download the latest Twistlock release from the [Twistlock doc site](https://docs.twistlock.com/docs/latest/download/releases.html).
+1. Download the latest Twistlock release from [Pivotal Network](https://network.pivotal.io).
 
-1. In the Ops Manager Installation Dashboard, click **Import a Product**.
-
-1. Select the tile from the Twistlock release directory.
-It can be found in TWISTLOCK-RELEASE/pivotal/twistlock-tile-VERSION.pivotal.
+1. In the Ops Manager Installation Dashboard, click **Import a Product**, and select the file you just downloaded.
 
 
 ##<a id='install'></a> Retrieve the Install Command
 
 Retrieve the install command from Twistlock Console.
 It is used to configure the tile.
+
+You should have installed Twistlock Console somewhere in your environment already.
+You can run it in Pivotal Container Service (PKS) or on a stand-alone virtual machine with Twistlock's Onebox install.
+For more information, see the [Twistlock doc site](https://docs.twistlock.com/docs/latest/install/getting_started.html).
 
 1. Log into Twistlock Console.
 


### PR DESCRIPTION
* First step now points to Pivotal Network to download the tile.
* Retrieve install command from Console: Repeat the Requirements section so that it's clear that you must install Console somewhere in your environment before installing Twistlock for PCF.